### PR TITLE
Zh add iter args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="spatial-lda", # Replace with your own username
-    version="0.0.3",
+    name="spatial-lda",
+    version="0.1.2",
     author="Zhenghao Chen, Vladimir Jojic",
     author_email="zhenghao@calicolabs.com, vjojic@calicolabs.com",
     description="Implementation of the Spatial-LDA model",

--- a/spatial_lda/admm.py
+++ b/spatial_lda/admm.py
@@ -134,7 +134,6 @@ def line_search(gamma, u, C, e, rho, s, t, l):
         step_max = np.min((step_max, np.min(u[neg_du] / (-du[neg_du]))))
 
     step = step_max * 0.99
-    r = compute_r(gamma, u, C, e, rho, s, t)
     for lsit in range(MAXLSITER):
         new_gamma = gamma + step * dgamma
         new_u = u + step * du

--- a/spatial_lda/admm.py
+++ b/spatial_lda/admm.py
@@ -309,13 +309,14 @@ def update_e(taus, v, rho):
     return taus + 1 / rho * v
 
 
-def update_xis(es, rho, D, s, verbosity=0, mu=2, primal_tol=1e-3):
+def update_xis(es, rho, D, s, max_iter=100, verbosity=0, mu=2, primal_tol=1e-3):
     n, k = es.shape
     l = D.shape[0]
     xis = []
     for i in range(k):
         e = es[:, [i]]
-        gamma, _ = primal_dual(e, rho, D, s, mu=mu, verbosity=verbosity, primal_tol=primal_tol)
+        gamma, _ = primal_dual(e, rho, D, s, max_iter=max_iter, mu=mu,
+                               verbosity=verbosity, primal_tol=primal_tol)
         xi, _ = split_gamma(gamma, n, 1, l)
         xis.append(xi)
     return np.concatenate(xis, axis=1)
@@ -325,9 +326,9 @@ def update_r(xis, v, cs, rho):
     return xis - 1 / rho * v + 1 / rho * cs
 
 
-def update_tau(r, rho, verbosity=0, max_iter=20):
+def update_tau(r, rho, verbosity=0, max_iter=20, ls_iter=10):
     new_taus = newton_regularized_dirichlet(
-        rho, r, max_iter=max_iter, verbosity=verbosity)
+        rho, r, max_iter=max_iter, ls_iter=ls_iter, verbosity=verbosity)
     assert np.all(new_taus > 0)
     return np.reshape(new_taus, r.shape)
 
@@ -346,8 +347,10 @@ def primal_objective(taus, cs, s, D):
     return objective
 
 
-def admm(cs, D, s, rho, verbosity=0, max_iter=15, max_dirichlet_iter=20, mu=2,
-         primal_tol=1e-3, threshold=None):
+def admm(cs, D, s, rho, verbosity=0, max_iter=15,
+         max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
+         max_primal_dual_iter=400,
+         mu=2, primal_tol=1e-3, threshold=None):
     """Performs an ADMM update to optimize per-cell topic prior Xi given LDA parameters.
 
     Reference: Modeling Multiplexed Images with Spatial-LDA Reveals Novel Tissue Microenvironments.
@@ -367,8 +370,11 @@ def admm(cs, D, s, rho, verbosity=0, max_iter=15, max_dirichlet_iter=20, mu=2,
              Xis to converge more quickly to a common consensus.
         verbosity: Whether to print debugging output.
         max_iter: Maximum number of ADMM iterations to run.
+        max_primal_dual_iter: Maximum number of primal-dual iterations to run.
         max_dirichlet_iter: Maximum number of newton steps to take in computing updates for tau (see 5.2.8 in the
                             appendix).
+        max_dirichlet_ls_iter: Maximum number of line-search steps to take in computing updates for tau
+                               (see 5.2.8 in the appendix).
         primal_tol: tolerance level for primal-dual updates.
         threshold: Cutoff for the percent change in the objective function.  Typical value is
             0.01.  If None, then all iterations in max_iter are executed.
@@ -385,7 +391,8 @@ def admm(cs, D, s, rho, verbosity=0, max_iter=15, max_dirichlet_iter=20, mu=2,
         es = update_e(taus, v, rho)
         start_xis = time.time()
         xis_old, taus_old = xis, taus
-        xis = update_xis(es, rho, D, s, verbosity=verbosity, mu=mu, primal_tol=primal_tol)
+        xis = update_xis(es, rho, D, s, max_iter=max_primal_dual_iter,
+                         verbosity=verbosity, mu=mu, primal_tol=primal_tol)
         if verbosity >= 1:
             duration = time.time() - start_xis
             logging.info(f'\tADMM Primal-Dual Fusion took:{duration:.2f} seconds')
@@ -395,6 +402,7 @@ def admm(cs, D, s, rho, verbosity=0, max_iter=15, max_dirichlet_iter=20, mu=2,
             r,
             rho,
             max_iter=max_dirichlet_iter,
+            ls_iter=max_dirichlet_ls_iter,
             verbosity=verbosity)
         if verbosity >= 1:
             duration = time.time() - start_tau

--- a/spatial_lda/model.py
+++ b/spatial_lda/model.py
@@ -13,7 +13,7 @@ import spatial_lda.admm as admm
 from spatial_lda.online_lda import LatentDirichletAllocation
 
 
-def _update_xi(counts, diff_matrix, diff_penalty, sample_id, verbosity=0,
+def _update_xi(counts, diff_matrix, diff_penalty, sample_id, verbosity=0, max_iter=15,
                max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
                rho=1e-1, mu=2.0, primal_tol=1e-3, threshold=None):
     if verbosity >= 1:
@@ -23,7 +23,7 @@ def _update_xi(counts, diff_matrix, diff_penalty, sample_id, verbosity=0,
     s = weight * np.ones(diff_matrix.shape[0])
     result = admm.admm(cs, diff_matrix, s, rho, verbosity=verbosity, mu=mu, primal_tol=primal_tol,
                        max_dirichlet_iter=max_dirichlet_iter, max_dirichlet_ls_iter=max_dirichlet_ls_iter,
-                       max_primal_dual_iter=max_primal_dual_iter,
+                       max_primal_dual_iter=max_primal_dual_iter, max_iter=max_iter,
                        threshold=threshold)
     if verbosity >= 1:
         logging.info(f'>>> Done inferring topic weights for sample {sample_id}')
@@ -37,7 +37,7 @@ def _wrap_update_xi(inputs):
 def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                 n_parallel_processes, verbosity, primal_dual_mu=2, admm_rho=0.1,
                 max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
-                primal_tol=1e-3, threshold=None):
+                max_iter=15, primal_tol=1e-3, threshold=None):
     sample_idxs = sample_features.index.map(lambda x: x[0])
     new_xis = np.zeros_like(gamma)
     if n_parallel_processes > 1:
@@ -54,6 +54,7 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                                  ('diff_matrix', sample_diff_matrices),
                                  ('diff_penalty', diff_penalties),
                                  ('sample_id', unique_idxs),
+                                 ('max_iter', max_iter),
                                  ('max_primal_dual_iter', max_primal_dual_iter),
                                  ('max_dirichlet_iter', max_dirichlet_iter),
                                  ('max_dirichlet_ls_iter', max_dirichlet_ls_iter),
@@ -84,6 +85,7 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                                               max_primal_dual_iter=max_primal_dual_iter,
                                               max_dirichlet_iter=max_dirichlet_iter,
                                               max_dirichlet_ls_iter=max_dirichlet_ls_iter,
+                                              max_iter=max_iter,
                                               verbosity=verbosity,
                                               rho=admm_rho,
                                               mu=primal_dual_mu,
@@ -94,7 +96,7 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
 
 def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
           max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
-          n_iters=3, n_parallel_processes=1, verbosity=0,
+          max_lda_iter=5, max_admm_iter=15, n_iters=3, n_parallel_processes=1, verbosity=0,
           primal_dual_mu=2, admm_rho=1.0, primal_tol=1e-3, threshold=None):
     """Train a Spatial-LDA model.
     
@@ -107,6 +109,8 @@ def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
         n_topics: Number of topics to fit.
         difference_penalty: Penalty on topic priors of "adjacent" index cells.
         n_iters: Number of outer-loop iterations (LDA + ADMM) to run.
+        max_lda_iter: Maximum number of LDA iterations to run.
+        max_admm_iter: Maximum number of ADMM iterations to run.
         max_primal_dual_iter: Maximum number of primal-dual iterations to run.
         max_dirichlet_iter: Maximum number of newton steps to take in computing updates for tau (see 5.2.8 in the
                             appendix).
@@ -130,7 +134,7 @@ def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
         logging.info(f'>>> Starting iteration {i}')
         m_step_start_time = time.time()
         lda = LatentDirichletAllocation(n_components=n_topics, random_state=0,
-                                        n_jobs=n_parallel_processes, max_iter=5,
+                                        n_jobs=n_parallel_processes, max_iter=max_lda_iter,
                                         doc_topic_prior=xis)
         lda.fit(sample_features.values)
         gamma = lda._unnormalized_transform(sample_features.values)
@@ -142,6 +146,7 @@ def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
                           difference_penalty=difference_penalty,
                           gamma=gamma,
                           n_parallel_processes=n_parallel_processes,
+                          max_iter=max_admm_iter,
                           max_primal_dual_iter=max_primal_dual_iter,
                           max_dirichlet_iter=max_dirichlet_iter,
                           max_dirichlet_ls_iter=max_dirichlet_ls_iter,
@@ -169,7 +174,7 @@ def _topic_name(i):
 
 def infer(components, sample_features, difference_matrices, difference_penalty=1,
           max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
-          n_parallel_processes=1):
+          max_admm_iter=15, n_parallel_processes=1):
     """Run inferrence on a Spatial-LDA model.
 
     This runs only the ADMM updates to get spatially-regularized topic weights on `sample_features`, allowing
@@ -183,6 +188,7 @@ def infer(components, sample_features, difference_matrices, difference_penalty=1
                              samples. (I.e., which cells should be regularized to have similar priors on topics).
                              (See featurization.make_merged_difference_matrices).
         difference_penalty: Penalty on topic priors of "adjacent" index cells.
+        max_admm_iter: Maximum number of ADMM iterations to run.
         max_primal_dual_iter: Maximum number of primal-dual iterations to run.
         max_dirichlet_iter: Maximum number of newton steps to take in computing updates for tau (see 5.2.8 in the
                             appendix).
@@ -207,6 +213,7 @@ def infer(components, sample_features, difference_matrices, difference_penalty=1
     xis = _update_xis(sample_features,
                       difference_matrices,
                       difference_penalty,
+                      max_iter=max_admm_iter,
                       max_primal_dual_iter=max_primal_dual_iter,
                       max_dirichlet_iter=max_dirichlet_iter,
                       max_dirichlet_ls_iter=max_dirichlet_ls_iter,

--- a/spatial_lda/model.py
+++ b/spatial_lda/model.py
@@ -14,6 +14,7 @@ from spatial_lda.online_lda import LatentDirichletAllocation
 
 
 def _update_xi(counts, diff_matrix, diff_penalty, sample_id, verbosity=0,
+               max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
                rho=1e-1, mu=2.0, primal_tol=1e-3, threshold=None):
     if verbosity >= 1:
         logging.info(f'>>> Infering topic weights for sample {sample_id}')
@@ -21,6 +22,8 @@ def _update_xi(counts, diff_matrix, diff_penalty, sample_id, verbosity=0,
     cs = digamma(counts) - digamma(np.sum(counts, axis=1, keepdims=True))
     s = weight * np.ones(diff_matrix.shape[0])
     result = admm.admm(cs, diff_matrix, s, rho, verbosity=verbosity, mu=mu, primal_tol=primal_tol,
+                       max_dirichlet_iter=max_dirichlet_iter, max_dirichlet_ls_iter=max_dirichlet_ls_iter,
+                       max_primal_dual_iter=max_primal_dual_iter,
                        threshold=threshold)
     if verbosity >= 1:
         logging.info(f'>>> Done inferring topic weights for sample {sample_id}')
@@ -33,6 +36,7 @@ def _wrap_update_xi(inputs):
 
 def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                 n_parallel_processes, verbosity, primal_dual_mu=2, admm_rho=0.1,
+                max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
                 primal_tol=1e-3, threshold=None):
     sample_idxs = sample_features.index.map(lambda x: x[0])
     new_xis = np.zeros_like(gamma)
@@ -50,6 +54,9 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                                  ('diff_matrix', sample_diff_matrices),
                                  ('diff_penalty', diff_penalties),
                                  ('sample_id', unique_idxs),
+                                 ('max_primal_dual_iter', max_primal_dual_iter),
+                                 ('max_dirichlet_iter', max_dirichlet_iter),
+                                 ('max_dirichlet_ls_iter', max_dirichlet_ls_iter),
                                  # Logging causes multiprocessing to get stuck
                                  # (https://pythonspeed.com/articles/python-multiprocessing/)
                                  ('verbosity', itertools.repeat(0)),                               
@@ -74,6 +81,9 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
                                               sample_diff_matrix,
                                               difference_penalty,
                                               sample_idx,
+                                              max_primal_dual_iter=max_primal_dual_iter,
+                                              max_dirichlet_iter=max_dirichlet_iter,
+                                              max_dirichlet_ls_iter=max_dirichlet_ls_iter,
                                               verbosity=verbosity,
                                               rho=admm_rho,
                                               mu=primal_dual_mu,
@@ -83,6 +93,7 @@ def _update_xis(sample_features, difference_matrices, difference_penalty, gamma,
 
 
 def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
+          max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
           n_iters=3, n_parallel_processes=1, verbosity=0,
           primal_dual_mu=2, admm_rho=1.0, primal_tol=1e-3, threshold=None):
     """Train a Spatial-LDA model.
@@ -96,6 +107,11 @@ def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
         n_topics: Number of topics to fit.
         difference_penalty: Penalty on topic priors of "adjacent" index cells.
         n_iters: Number of outer-loop iterations (LDA + ADMM) to run.
+        max_primal_dual_iter: Maximum number of primal-dual iterations to run.
+        max_dirichlet_iter: Maximum number of newton steps to take in computing updates for tau (see 5.2.8 in the
+                            appendix).
+        max_dirichlet_ls_iter: Maximum number of line-search steps to take in computing updates for tau
+                               (see 5.2.8 in the appendix).
         n_parallel_processes: Number of parallel processes to use.
         verbosity: Amount of debug / info updates to see.
         primal_dual_mu: mu used in primal-dual updates (see paper for more details).
@@ -126,6 +142,9 @@ def train(sample_features, difference_matrices, n_topics, difference_penalty=1,
                           difference_penalty=difference_penalty,
                           gamma=gamma,
                           n_parallel_processes=n_parallel_processes,
+                          max_primal_dual_iter=max_primal_dual_iter,
+                          max_dirichlet_iter=max_dirichlet_iter,
+                          max_dirichlet_ls_iter=max_dirichlet_ls_iter,
                           verbosity=verbosity,
                           primal_dual_mu=primal_dual_mu,
                           admm_rho=admm_rho,
@@ -149,6 +168,7 @@ def _topic_name(i):
 
 
 def infer(components, sample_features, difference_matrices, difference_penalty=1,
+          max_primal_dual_iter=400, max_dirichlet_iter=20, max_dirichlet_ls_iter=10,
           n_parallel_processes=1):
     """Run inferrence on a Spatial-LDA model.
 
@@ -163,6 +183,11 @@ def infer(components, sample_features, difference_matrices, difference_penalty=1
                              samples. (I.e., which cells should be regularized to have similar priors on topics).
                              (See featurization.make_merged_difference_matrices).
         difference_penalty: Penalty on topic priors of "adjacent" index cells.
+        max_primal_dual_iter: Maximum number of primal-dual iterations to run.
+        max_dirichlet_iter: Maximum number of newton steps to take in computing updates for tau (see 5.2.8 in the
+                            appendix).
+        max_dirichlet_ls_iter: Maximum number of line-search steps to take in computing updates for tau
+                               (see 5.2.8 in the appendix).
         n_parallel_processes: Number of parallel processes to use.
 
     Returns:
@@ -182,6 +207,9 @@ def infer(components, sample_features, difference_matrices, difference_penalty=1
     xis = _update_xis(sample_features,
                       difference_matrices,
                       difference_penalty,
+                      max_primal_dual_iter=max_primal_dual_iter,
+                      max_dirichlet_iter=max_dirichlet_iter,
+                      max_dirichlet_ls_iter=max_dirichlet_ls_iter,
                       gamma=gamma,
                       n_parallel_processes=n_parallel_processes,
                       verbosity=0)


### PR DESCRIPTION
QoL change for adding options to control:
 - LDA iterations (previously fixed to 5)
 - ADMM outer loop iterations (previously fixed to 15)
 - Newton steps and line search iterations for fusion problem
 - Primal-dual iterations when updating Xi

Also removed a redundant call to `compute_r`